### PR TITLE
build: add basic ci workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install
+      run: sudo apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libpango1.0-dev
+    - name: autoconf
+      run: autoreconf -vif
+    - name: build locale
+      run: cd locale && ./build.py && cd ..
+    - name: configure
+      run: ./configure
+    - name: build
+      run: make


### PR DESCRIPTION
Add a GitHub Action workflow for basic continuous integration on Linux.

This should serve as a reasonable starting point for setting up cross-platform CI.

I've tested it in igilham/starfighter#1